### PR TITLE
docs(comments): add explanatory headers & inline rationale across MVP files

### DIFF
--- a/MVP/backend/starters.py
+++ b/MVP/backend/starters.py
@@ -1,8 +1,26 @@
+"""
+starters.py - Starter Pokemon definitions (future-facing)
+
+Intent:
+- Centralize starter Pokemon metadata across generations.
+- MVP currently only consumes a small subset via `battle_engine.py`.
+- This file is structured as a Flask Blueprint for future expansion.
+
+Notes:
+- For MVP, data is hardcoded and partially incomplete.
+- Post-MVP, expand to return richer payloads: pokedexId, name, type(s), sprite URL,
+    normalized move data, etc.
+"""
+
 from flask import Blueprint, jsonify
 
 starters_bp = Blueprint("starters", __name__)
 
-# All starters (key, pokedex_id) Expandable later
+# ================================
+# Starer Pokemon Data
+# ================================
+
+# All starters (key, pokedexid) Expandable later
 ALL_STARTERS = [
     #Gen 1
     ("bulbasaur", 1), ("charmander", 4), ("squirtle", 7),
@@ -17,3 +35,8 @@ ALL_STARTERS = [
     #Gen 8
     #Gen 9
 ]
+
+# TODO(mvp-exit):
+# - Normalize starter data into full dict objects:
+#   { "pokedexId": int, "name": str, "types": [str], "spriteUrl": str, "moves": [] }
+# - Wire this endpoint into frontend starter selection screen.

--- a/MVP/frontend/src/screens/BattleScreen.jsx
+++ b/MVP/frontend/src/screens/BattleScreen.jsx
@@ -1,10 +1,26 @@
+/**
+ * BattleScreen.jsx - MVP battle UI
+ * 
+ * Intent:
+ * - Renders a single battle between two starters.
+ * - Frontend never computes outcomes - it calls Flask (`battle_engine.py`) and renders.
+ * - Only the newest message animates; older ones are stored in a static history.
+ * 
+ * Contracts:
+ * - POST /api/battle/start -> { battle_id, player, enemy, status, message_log[] }
+ * - POST /api/battle/turn  -> { battle_id, player, enemy, status, message_log[], turn_log[] }
+ * 
+ * Notes:
+ * - Keep UX simple and deterministic for MVP (lock input while message animate).
+ * - Exit criteria (mvp-exit): wire real StarterSelect, extract MessageBox, add status/HP UI polish.
+ */
 import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 
 /**
-    * Minimal MVP Battle Screen
-    * - Hardcoded matchup: charmander vs squirtle
-    * - Calls Flask POST /api/battle
-    * - Renders HP, sprites, log, and outcome
+ * Minimal MVP Battle Screen (structure overview)
+ * - Hardocded matchup: charmander vs squirtle (rpelace via StarterSelect later).
+ * - Calls Flask endpoints for battle start/turn; server is the source of truth.
+ * - Renders HP, sprites, animated current message, non-animated history, and outcome.
  */
 
 const INITIAL_HP = { 
@@ -18,9 +34,15 @@ const SPRITES = (name) => `/assets/sprites/${name}.png`;
 const Capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1);
 
 /** 
- * Simplified typing effect for an array of lines.
- * Reveals characters one-by-one for the current line; when a line finishes,
- * it moves that line into history and continues with the next.
+ * MessageBox - simple typewriter for a queue of lines.
+ * Behavior:
+ * - When the queue head changes, start typing that line character-by-character.
+ * - Clicking (or pressing Space/Enter):
+ *   - If typing: instantly completes the current line.
+ *   - If idle and there are queued lines: signals completion of the head line.
+ * Guardrails:
+ * - Respects `inputLocked` so the user can't fast-forward while a network call is pending.
+ * - The parent owns the queue and removes items via `onFinishOne`.
  */
 function MessageBox({ queue, onFinishOne, inputLocked, promptText }) {
     const [displayed, setDisplayed] = useState("");
@@ -31,6 +53,7 @@ function MessageBox({ queue, onFinishOne, inputLocked, promptText }) {
     useEffect(() => {
         const next = queue[0] ?? "";
         if(!next) {
+            // No message: clear local buffers and stop typing.
             setDisplayed("");
             setFull("")
             setTyping(false);
@@ -41,15 +64,16 @@ function MessageBox({ queue, onFinishOne, inputLocked, promptText }) {
         setFull(next);
         setTyping(true);
 
+        // Typewriter effect - reveals one character every 18ms.
         let i = 0;
         let timer;
         const step = () => {
             i++;
             setDisplayed(next.slice(0,i));
             if ( i < next.length) {
-                timer = setTimeout(step, 18);   // type speed (ms per char)
+                timer = setTimeout(step, 18);   // speed (ms per char)
             } else {
-                setTyping(false);
+                setTyping(false);               // finished this line
             }
         };
         timer = setTimeout(step, 18);
@@ -57,17 +81,18 @@ function MessageBox({ queue, onFinishOne, inputLocked, promptText }) {
     }, [queue]);
 
     const advance = useCallback(() => {
-        if (inputLocked) return;
+        if (inputLocked) return;  // don't advance while network is resolving
         if (typing) {
-            // Finish instantly
+            // Complete the current line instantly.
             setDisplayed(full);
             setTyping(false);
         } else if (queue.length) {
-            onFinishOne(queue[0]);   // remove the head, start next message
+            // Notify parent that the head line finished; parent will dequeue.
+            onFinishOne(queue[0]);
         }
     }, [typing, full, queue, onFinishOne, inputLocked]);
 
-    // Keyboard: Space / Enter advances
+    // Keyboard afforance: Space / Enter mirrors click behavior.
     useEffect(() => {
         const onKey = (e) => {
             if (e.key === " " || e.key === "Enter") advance();
@@ -85,9 +110,10 @@ function MessageBox({ queue, onFinishOne, inputLocked, promptText }) {
             tabIndex={0}
         >
             <div className="msg-text">
+                {/* If there are messages, show the animated line; otherwise show the prompt (or a blank space to preserve layout) */}
                 {queue.length > 0 ? (displayed || " ") : (promptText || " ")}
             </div>
-            {/* Always render the arrow; hide it when not needed */}
+            {/* Chevron hint - always rendered for layout stability; hidden while typing or when no messages */}
             <div className={`msg-next ${(!typing && queue.length > 0) ? "" : "msg-next--hidden"}`}>
                 ▶
             </div>
@@ -108,17 +134,17 @@ export default function BattleScreen() {
     const [enemyHP, setEnemyHP] = useState(INITIAL_HP[enemyKey]);
     const [status, setStatus] = useState("ongoing");
 
-    const [busy, setBusy] = useState(false);        // network busy
+    const [busy, setBusy] = useState(false);        // network busy flag (locks input)
     const [queue, setQueue] = useState([]);         // pending messages to animate
 
     const [history, setHistory] = useState([]);     // array of {turn, message[] }
-    const pendingTurnMessages = useRef([]);
-    const currentTurnRef = useRef(0);
+    const pendingTurnMessages = useRef([]);         // collects lines for the current turn
+    const currentTurnRef = useRef(0);               // stamped turn index for history grouping
 
     const playerSprite = useMemo(() => SPRITES(playerKey), [playerKey]);
     const enemySprite = useMemo(() => SPRITES(enemyKey), [enemyKey]);
 
-    // Start a persistent battle on mount
+    // on mount: create a persistent battle on the server and intialize local state.
     useEffect(() => {
         let cancelled = false;
         (async () => {
@@ -141,7 +167,7 @@ export default function BattleScreen() {
                 setPlayerName(data?.player?.name ?? Capitalize(playerKey));
                 setEnemyName(data?.enemy?.name ?? Capitalize(enemyKey));
 
-                // On start: commit any initial messages to history, keep queue empty
+                // Commit any intial server messages to history; keep the animation queue empty.
                 const initial = Array.isArray(data.message_log) ? data.message_log : [];
                 if (initial.length > 0) {
                     setHistory([{turn: 0, messages: initial }]);
@@ -165,27 +191,35 @@ export default function BattleScreen() {
         };
     }, [playerKey, enemyKey]);
 
-    // Remove the head of the queue
+    /**
+     * finsihOneMessage - called by MessageBox when the current line completes.
+     * Responsibility:
+     * - Dequeue the head line.
+     * - Accumulate completed lines for the current turn in `pendingTurnMessages`.
+     * - When the queue becomes empty, commit the collected lines to the history
+     *   under the currently stamepd turn number (de-duplicated).
+     */
     const finishOneMessage = useCallback((msg) => {
         setQueue((qPrev) => {
             const nextQ = qPrev.slice(1);
             const willBeEmpty = nextQ.length === 0;
 
-            // Accumulate this lice for the active turn
+            // Accumulate this line for the active turn
             pendingTurnMessages.current = [...pendingTurnMessages.current, msg];
 
             if (willBeEmpty) {
-                // No lines collect? Don't create an empty header
+                // If nothing collected, don't append an empty history block.
                 if (pendingTurnMessages.current.length === 0) return nextQ;
 
                 const turn = currentTurnRef.current; // <--- commit to the stamped turn
                 setHistory((hPrev) => {
+                    // If the last history entry is the same turn, merge into it; else append a new entry.
                     if (hPrev.length && hPrev[hPrev.length - 1].turn === turn) {
                         const last = hPrev[hPrev.length - 1];
                         const merged = {
                             ...last,
                             messages:[...last.messages, ...pendingTurnMessages.current]
-                            .filter((line, i, arr) => arr.indexOf(line) === i),
+                            .filter((line, i, arr) => arr.indexOf(line) === i), // de-dup
                         };
                         pendingTurnMessages.current = [];
                         return [...hPrev.slice(0, -1), merged];
@@ -205,9 +239,17 @@ export default function BattleScreen() {
         });
     }, []);
 
-    // Send a turn for this battle_id
+    /**
+     * 
+     * handleMove - send the selected move to the backend for resolution.
+     * Guardrails:
+     * - Lock input while busy.
+     * - Do not allow new input while there are messages still animating (classic Pokemon UX).
+     * - Use only the delta `turn_log` returned from the server to populate the queue.
+     */
+
     const handleMove = async (move) => {
-        // lock input if still messages to finish (Pokemon behavior)
+        // Lock input if messages remain or the battle isn't ongoing.
         if (busy || status !== "ongoing" || !battleId || queue.length > 0) return;
         setBusy(true);
         try {
@@ -223,17 +265,18 @@ export default function BattleScreen() {
             setEnemyHP(data.enemy.current_hp);
             setStatus(data.status);
 
-            // Start a fresh collector and stamp the turn we are building now
+            // Stamp the turn we're building; history shows one block per turn.
             const lastTurn = history.length ? history[history.length-1].turn : 0;
             currentTurnRef.current = lastTurn === 0 ? 1 : lastTurn + 1;
             pendingTurnMessages.current = []
 
-            // Use ONLY the delta for this turn; normalize to array defensively
+            // Nomralize incoming to an array and de-duplicate; append to queue.
             let incoming = data.turn_log;
             if (typeof incoming === "string") incoming = [incoming];
             if (!Array.isArray(incoming)) incoming = [];
             incoming = incoming.filter((line, index, arr) => arr.indexOf(line) === index);
             setQueue((q) => {
+                // Edge: avoid duplicating the first line if it equals our last queued line.
                 const safe = (q.length && incoming.length && q[q.length-1] === incoming[0])
                 ? incoming.slice(1)
                 : incoming;
@@ -253,6 +296,7 @@ export default function BattleScreen() {
         <div className="screen-container">
             <h1>Battle!</h1>
 
+            {/* Enemy HUD */}
             <div className="pokemon-block">
                 <div className="pokemon-name">
                     {enemyName} - {enemyHP} HP
@@ -260,6 +304,7 @@ export default function BattleScreen() {
                 <img className="pokemon-sprite" src={enemySprite} alt={`${enemyKey} sprite`} />
             </div>
 
+            {/* Player HUD */}
             <div className="pokemon-block">
                 <div className="pokemon-name">
                     {playerName} - {playerHP} HP
@@ -267,6 +312,7 @@ export default function BattleScreen() {
                 <img className="pokemon-sprite" src={playerSprite} alt={`${playerKey} sprite`} />
             </div>
 
+            {/* Move Buttons - disabled while busy or while messages are animating */}
             {status === "ongoing" ? (
                 <>
                     <div className="move-buttons">
@@ -289,7 +335,7 @@ export default function BattleScreen() {
                 promptText={canAct ? `What will ${playerName} do?` : ""}
             />
 
-            {/* History Box (non-animated) */}
+            {/* History: one block per completed turn with an ordered list of lines */}
             <div className="msg-history">
                 {history.map((turnObj, i) => (
                     <div key={`${turnObj.turn}-${i}`} className="msg-history-turn">

--- a/MVP/frontend/src/screens/MainMenu.jsx
+++ b/MVP/frontend/src/screens/MainMenu.jsx
@@ -1,13 +1,28 @@
+/**
+ * MainMenu.jsx - MVP landing screen
+ * 
+ * Intent:
+ * - Serve as the first screen after welcome.
+ * - Read the transient player name from localStorage (MVP has no user accounts).
+ * - Provide a simple entry point; fuller meno arrives post-MVP.
+ * 
+ * Contact:
+ * - `WelcomeScreen` writes localStorage["playerName"] before navigating here.
+ * 
+ * Notes:
+ * - Keep this screen minimal to reduce cognitive load during MVP reviews.
+ * - Post-MVP we'll add navigation to Starter Select, Settings, etc.
+ */
 import React from "react";
 
 export default function MainMenu() {
-    const playerName = localStorage.getItem("playerName");
+    const playerName = localStorage.getItem("playerName"); // single source of truth in MVP
 
     return (
         <div className="screen-container">
             <h1>Main Menu</h1>
             <p>Welcome, {playerName}!</p>
-            {/* future menu buttons go here */}
+            {/* TODO(mvp-exit): Add real menu options (New Game -> Starter Select, Settings, Credits). */}
         </div>
     )
 } 

--- a/MVP/frontend/src/screens/WelcomeScreen.jsx
+++ b/MVP/frontend/src/screens/WelcomeScreen.jsx
@@ -1,21 +1,44 @@
+/**
+ * WelcomeScreen.jsc
+ * 
+ * Purpose:
+ * - First screen the player sees when launching the game.
+ * - Allows the player to enter a name, which is saved in localStorage.
+ * - After entering a name, routes the player to the Main Menu.
+ * 
+ * Key points for contributors:
+ * - Player name is persisted via localStorage (no backend required for MVP).
+ * - This is part of the MVP flow: Welcome -> Main Menu -> Starter Select -> Battle.
+ */
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 export default function WelcomeScreen() {
+    // Store the current input value for the player's name.
     const [name, setName] = useState("");
+
+    // React Router hook: lets us programatically change pages.
     const navigate = useNavigate();
+
+    /**
+     * Handle the "Continue" button.
+     * - Save the player's name into localStorage.
+     * - Redirect to the Main Menu.
+     */
 
     const handleContinue = () => {
         const timmedName = name.trim();
         if (!timmedName) return alert("Please emter your name");
         
         localStorage.setItem("playerName", timmedName);
-        navigate("/main-menu");
+        navigate("/main-menu");  // move to the main menu screen
     };
 
     return (
         <div className="screen-container">
             <h1>Welcome to RogueMon</h1>
+
+            {/* Text input: player types their name here */ }
             <input
                 type="text"
                 placeholder="Enter your name"
@@ -23,6 +46,8 @@ export default function WelcomeScreen() {
                 onChange={(e) => setName(e.target.value)}
                 className="input-field"
             />
+
+            {/* Button: confirms name and continues */}
             <button onClick={handleContinue} className="primary-button">
                 Continue
             </button>


### PR DESCRIPTION
Context
- Comments only pass to improve reviewer onboarding and intent clarity

Changes
- Added file headers (intent, scope, contracts, non-goals).
- Added docstrings and "why" breadcrumbs in complex spots.
- Left runtime logic untouched (no behavior changes).

Risk
- None (comments-only). Path verified for MVP structure.

Follow-ups
- Separate PR will fix small typos (e.g., console.err) and wire StarterSelect.