### PR TITLE
feat: implement battle end flow (capture/skip/next battle + game over)

### DIFF
--- a/MVP/frontend/src/index.css
+++ b/MVP/frontend/src/index.css
@@ -302,3 +302,22 @@ animation: msg-blink 1s steps(2, start) infinite;
   .starter-card { border-color: #444; background: rgba(255,255,255,0.06); }
   .button, .button-secondary { border-color: #444; background: rgba(255,255,255,0.06); }
 }
+
+/* BattleScreen - post-battle */
+.capture-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+}
+
+.capture-message {
+  margin-top: 8px;
+  text-align: center;
+}
+
+.post-battle-action {
+  margin-top: 10px;
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
### Summary
Implements full battle end flow:
- All fainted/capture/skip messages go through the MessageBox
- Messages are suppressed from entering the history
- Capture prompt shown after fainting
- Capture result/skip shown via MessageBox
- Next Battle and Play Again buttons appear after messages finish

### Testing
- Win → shows faint → capture prompt → capture result or skip → Next Battle
- Lose → shows faint → Play Again
- Capture result stored in sessionStorage["party"]